### PR TITLE
Saves 25 gifs from each request and ensures every forecast day has a unique gif

### DIFF
--- a/app/models/gif.rb
+++ b/app/models/gif.rb
@@ -1,3 +1,9 @@
 class Gif < ApplicationRecord
-  belongs_to :city
+
+  def self.save_from_array(array, icon)
+    array.each do |hash|
+      Gif.find_or_create_by!(icon: icon, gif_url: hash[:embed_url])
+    end
+  end
+
 end

--- a/app/retrievers/gif_retriever.rb
+++ b/app/retrievers/gif_retriever.rb
@@ -1,10 +1,15 @@
 class GifRetriever
   def find_or_fetch(forecast_child)
-    if found_gif = find_gif(forecast_child)
+    if found_gif = find_unique_gif(forecast_child)
       found_gif
     else
-      Gif.new(service(forecast_child).gif_data)
+      Gif.save_from_array(service(forecast_child).all_gif_data, forecast_child.icon)
+      find_unique_gif(forecast_child)
     end
+  end
+
+  def fetch(index)
+    Gif.new(service(forecast_child, index).one_gif_data)
   end
 
   def initialize(forecast)
@@ -12,19 +17,28 @@ class GifRetriever
   end
 
   def days
-    @forecast.days.map do |day|
-      find_or_fetch(day)
+    @_days = []
+    @forecast.days.each do |day|
+      @_days << find_or_fetch(day)
     end
+    @_days
   end
 
-  def find_gif(forecast_child)
-    Gif.find_by(icon: forecast_child.icon)
+  def already_used_gif_urls
+    @_days.pluck(:gif_url)
+  end
+
+  def find_unique_gif(forecast_child)
+    Gif.where(icon: forecast_child.icon)
+       .where.not(gif_url: [already_used_gif_urls])
+       .first
   end
 
   private
 
-  def service(forecast_child)
-    GiphyService.new(forecast_child: forecast_child, city: @forecast.city)
+  def service(forecast_child, index = 0)
+    GiphyService.new(forecast_child: forecast_child,
+                      city: @forecast.city)
   end
 
 

--- a/app/services/giphy_service.rb
+++ b/app/services/giphy_service.rb
@@ -4,12 +4,16 @@ class GiphyService
     @forecast_child = args[:forecast_child]
   end
 
-  def gif_data
+  def one_gif_data
     {
       summary: @forecast_child.summary,
       time: @forecast_child.time,
       gif_url: get_gif_url,
     }
+  end
+
+  def all_gif_data
+    parse_gif_data[:data]
   end
 
   private
@@ -31,7 +35,6 @@ class GiphyService
       f.adapter Faraday.default_adapter
       f.params[:api_key] = ENV['GIPHY_API_KEY']
       f.params[:q] = @forecast_child.icon
-      f.params[:limit] = 1
       f.params[:offset] = 0
       f.params[:rating] = 'G'
       f.params[:lang] = 'en'

--- a/spec/requests/api/v1/gif_request_spec.rb
+++ b/spec/requests/api/v1/gif_request_spec.rb
@@ -18,5 +18,7 @@ describe 'gif endpoint' do
     expect(days.first).to have_key(:summary)
     expect(days.first).to have_key(:gif_url)
     expect(days.first.keys.count).to eq(3)
+    urls = days.map{ |day| day[:gif_url]}
+    expect(urls.uniq.size).to eq(urls.size)
   end
 end


### PR DESCRIPTION
Branch from when I had extra time during a timed challenge.
---
Succeeds in: 
1. Saving the gifs
2. Getting a unique gif for each day even when the icons are the same. And they're pretty good and relevant! Ran through it on localhost. It works!

However...
Unlike on the master branch, the summary and time return nil. Funny, has_key? doesn't test for this.
I had been saving the summary and time to the gifs in the database. In retrospect, really only the gif PORO needs this. 
Could fix with some refactoring.

Feature test was used to drive, no unit testing added